### PR TITLE
support for xml report

### DIFF
--- a/src/main/java/org/sonarlint/cli/Main.java
+++ b/src/main/java/org/sonarlint/cli/Main.java
@@ -65,6 +65,8 @@ public class Main {
 
     reportFactory.setHtmlPath(opts.htmlReport());
 
+    reportFactory.setXmlPath(opts.xmlReport());
+
     LOGGER.setDebugEnabled(opts.isVerbose());
     LOGGER.setDisplayStackTrace(opts.showStack());
 

--- a/src/main/java/org/sonarlint/cli/Options.java
+++ b/src/main/java/org/sonarlint/cli/Options.java
@@ -33,6 +33,7 @@ public class Options {
   private boolean showStack = false;
   private boolean interactive = false;
   private String htmlReport = null;
+  private String xmlReport = null;
   private String src = null;
   private String tests = "";
   private String charset = null;
@@ -71,6 +72,10 @@ public class Options {
         if ("--html-report".equals(arg)) {
           checkAdditionalArg(i, args.length, arg);
           options.htmlReport = args[i];
+
+        } else if ("--xml-report".equals(arg)) {
+          checkAdditionalArg(i, args.length, arg);
+          options.xmlReport = args[i];
 
         } else if ("--charset".equals(arg)) {
           checkAdditionalArg(i, args.length, arg);
@@ -123,6 +128,10 @@ public class Options {
     return htmlReport;
   }
 
+  public String xmlReport() {
+    return xmlReport;
+  }
+
   public String src() {
     return src;
   }
@@ -159,6 +168,7 @@ public class Options {
     LOGGER.info(" -X,--debug             Produce execution debug output");
     LOGGER.info(" -i,--interactive       Run interactively");
     LOGGER.info(" --html-report <path>   HTML report output path (relative or absolute)");
+    LOGGER.info(" --xml-report <path>    XML report output path (relative or absolute)");
     LOGGER.info(" --src <glob pattern>   GLOB pattern to identify source files");
     LOGGER.info(" --tests <glob pattern> GLOB pattern to identify test files");
     LOGGER.info(" --charset <name>       Character encoding of the source files");

--- a/src/main/java/org/sonarlint/cli/report/ReportFactory.java
+++ b/src/main/java/org/sonarlint/cli/report/ReportFactory.java
@@ -32,6 +32,7 @@ import java.util.List;
 public class ReportFactory {
   private static final String DEFAULT_REPORT_PATH = ".sonarlint/sonarlint-report.html";
   private String htmlPath = null;
+  private String xmlPath = null;
   private Charset charset;
 
   public ReportFactory(Charset charset) {
@@ -42,7 +43,10 @@ public class ReportFactory {
     List<Reporter> list = new LinkedList<>();
 
     list.add(new ConsoleReport());
-    list.add(new HtmlReport(basePath, getReportFile(basePath), new SourceProvider(charset)));
+    list.add(new HtmlReport(basePath, getReportFile(basePath, htmlPath), new SourceProvider(charset)));
+    if (xmlPath != null) {
+      list.add(new XmlReport(basePath, getReportFile(basePath, xmlPath), new SourceProvider(charset)));
+    }
 
     return list;
   }
@@ -51,11 +55,19 @@ public class ReportFactory {
     htmlPath = path;
   }
 
+  public void setXmlPath(@Nullable String path) {
+    xmlPath = path;
+  }
+
   Path getReportFile(Path basePath) {
+    return getReportFile(basePath, null);
+  }
+
+  Path getReportFile(Path basePath, String filePath) {
     Path reportPath;
 
-    if (htmlPath != null) {
-      reportPath = Paths.get(htmlPath);
+    if (filePath != null) {
+      reportPath = Paths.get(filePath);
 
       if (!reportPath.isAbsolute()) {
         reportPath = basePath.resolve(reportPath).toAbsolutePath();

--- a/src/main/java/org/sonarlint/cli/report/XmlReport.java
+++ b/src/main/java/org/sonarlint/cli/report/XmlReport.java
@@ -1,0 +1,90 @@
+/*
+ * SonarLint CLI
+ * Copyright (C) 2016-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.cli.report;
+
+import freemarker.template.Template;
+import org.sonarlint.cli.util.Logger;
+import org.sonarsource.sonarlint.core.AnalysisResults;
+import org.sonarsource.sonarlint.core.IssueListener;
+
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class XmlReport implements Reporter {
+  private static final Logger LOGGER = Logger.get();
+  private final Path reportFile;
+  private final Path reportDir;
+  private final SourceProvider sourceProvider;
+  private Path basePath;
+
+  public XmlReport(Path basePath, Path reportFile, SourceProvider sourceProvider) {
+    this.basePath = basePath;
+    this.sourceProvider = sourceProvider;
+    this.reportDir = reportFile.getParent().toAbsolutePath();
+    this.reportFile = reportFile.toAbsolutePath();
+  }
+
+  @Override
+  public void execute(String projectName, Date date, List<IssueListener.Issue> issues, AnalysisResults result) {
+    IssuesReport report = new IssuesReport(basePath);
+    for (IssueListener.Issue i : issues) {
+      report.addIssue(i);
+    }
+    report.setTitle(projectName);
+    report.setDate(date);
+    report.setFilesAnalyzed(result.fileCount());
+    print(report);
+  }
+
+  public void print(IssuesReport report) {
+    LOGGER.debug("Generating SonarLint XML Report to: " + reportFile);
+    writeToFile(report, reportFile);
+    LOGGER.info("SonarLint XML Report generated: " + reportFile);
+  }
+
+  private void writeToFile(IssuesReport report, Path toFile) {
+    try {
+      freemarker.log.Logger.selectLoggerLibrary(freemarker.log.Logger.LIBRARY_NONE);
+      freemarker.template.Configuration cfg = new freemarker.template.Configuration();
+      cfg.setClassForTemplateLoading(XmlReport.class, "");
+
+      Map<String, Object> root = new HashMap<>();
+      root.put("report", report);
+      root.put("sources", sourceProvider);
+
+      Template template = cfg.getTemplate("sonarlintxmlreport.ftl");
+
+      try (FileOutputStream fos = new FileOutputStream(toFile.toFile());
+           Writer writer = new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
+        template.process(root, writer);
+        writer.flush();
+      }
+    } catch (Exception e) {
+      throw new IllegalStateException("Fail to generate XML Issues Report to: " + toFile, e);
+    }
+  }
+}

--- a/src/main/resources/org/sonarlint/cli/report/sonarlintxmlreport.ftl
+++ b/src/main/resources/org/sonarlint/cli/report/sonarlintxmlreport.ftl
@@ -4,8 +4,8 @@
   <#list report.getResourceReports() as resourceReport>
     <file name="${resourceReport.getName()}">
       <issues total="${resourceReport.getTotal().getCountInCurrentAnalysis()?c}">
-        <#list resourceReport.getCategoryReports() as categoryReport>
-        <issue severity="${categoryReport.getSeverity()?lower_case}" count="${categoryReport.getTotal().getCountInCurrentAnalysis()?c}">${categoryReport.getName()?xml}</issue>
+        <#list resourceReport.getIssues() as issue>
+        <issue severity="${issue.getSeverity()?lower_case}" key="${issue.getRuleKey()?xml}" name="${issue.getRuleName()?xml}" line="${(issue.getStartLine()!0)?c}" offset="${(issue.getStartLineOffset()!0)?c}"/>
         </#list>
       </issues>
     </file>

--- a/src/main/resources/org/sonarlint/cli/report/sonarlintxmlreport.ftl
+++ b/src/main/resources/org/sonarlint/cli/report/sonarlintxmlreport.ftl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<sonarlintreport>
+  <files>
+  <#list report.getResourceReports() as resourceReport>
+    <file name="${resourceReport.getName()}">
+      <issues total="${resourceReport.getTotal().getCountInCurrentAnalysis()?c}">
+        <#list resourceReport.getCategoryReports() as categoryReport>
+        <issue severity="${categoryReport.getSeverity()?lower_case}" count="${categoryReport.getTotal().getCountInCurrentAnalysis()?c}">${categoryReport.getName()?xml}</issue>
+        </#list>
+      </issues>
+    </file>
+  </#list>
+  </files>
+</sonarlintreport>

--- a/src/test/java/org/sonarlint/cli/report/BaseReportTest.java
+++ b/src/test/java/org/sonarlint/cli/report/BaseReportTest.java
@@ -1,0 +1,47 @@
+/*
+ * SonarLint CLI
+ * Copyright (C) 2016-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarlint.cli.report;
+
+import org.sonarsource.sonarlint.core.IssueListener;
+
+import java.nio.file.Paths;
+
+public abstract class BaseReportTest {
+
+  static IssueListener.Issue createTestIssue(String filePath, String ruleKey, String severity, int line) {
+    IssueListener.Issue issue = new IssueListener.Issue();
+    issue.setStartLine(line);
+    issue.setFilePath(Paths.get(filePath));
+    issue.setRuleKey(ruleKey);
+    issue.setSeverity(severity);
+    return issue;
+  }
+
+  static IssueListener.Issue createTestIssue(String filePath, String ruleKey, String ruleName, String severity, int line) {
+    IssueListener.Issue issue = new IssueListener.Issue();
+    issue.setStartLine(line);
+    issue.setFilePath(Paths.get(filePath));
+    issue.setRuleKey(ruleKey);
+    issue.setRuleName(ruleName);
+    issue.setSeverity(severity);
+    return issue;
+  }
+
+}

--- a/src/test/java/org/sonarlint/cli/report/ConsoleReportTest.java
+++ b/src/test/java/org/sonarlint/cli/report/ConsoleReportTest.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ConsoleReportTest {
+public class ConsoleReportTest extends BaseReportTest {
   private final static String PROJECT_NAME = "project";
   private final static Date DATE = new Date(System.currentTimeMillis());
   @Rule
@@ -135,14 +135,5 @@ public class ConsoleReportTest {
     stdOut = new PrintStream(out);
     stdErr = new PrintStream(err);
     Logger.set(stdOut, stdErr);
-  }
-
-  private static IssueListener.Issue createTestIssue(String filePath, String ruleKey, String severity, int line) {
-    IssueListener.Issue issue = new IssueListener.Issue();
-    issue.setStartLine(line);
-    issue.setFilePath(Paths.get(filePath));
-    issue.setRuleKey(ruleKey);
-    issue.setSeverity(severity);
-    return issue;
   }
 }

--- a/src/test/java/org/sonarlint/cli/report/ReportFactoryTest.java
+++ b/src/test/java/org/sonarlint/cli/report/ReportFactoryTest.java
@@ -56,8 +56,7 @@ public class ReportFactoryTest {
 
   @Test
   public void customReportFile() {
-    factory.setHtmlPath(Paths.get("myreport", "myfile.html").toString());
-    Path report = factory.getReportFile(temp.getRoot().toPath());
+    Path report = factory.getReportFile(temp.getRoot().toPath(), Paths.get("myreport", "myfile.html").toString());
     assertThat(report).isEqualTo(temp.getRoot().toPath().resolve("myreport").resolve("myfile.html"));
   }
 }

--- a/src/test/java/org/sonarlint/cli/report/XmlReportTest.java
+++ b/src/test/java/org/sonarlint/cli/report/XmlReportTest.java
@@ -19,10 +19,6 @@
  */
 package org.sonarlint.cli.report;
 
-import java.nio.file.Path;
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,11 +26,16 @@ import org.junit.rules.TemporaryFolder;
 import org.sonarsource.sonarlint.core.AnalysisResults;
 import org.sonarsource.sonarlint.core.IssueListener;
 
+import java.nio.file.Path;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class HtmlReportTest extends BaseReportTest {
-  private HtmlReport html;
+public class XmlReportTest extends BaseReportTest {
+  private XmlReport xml;
   private AnalysisResults result;
 
   @Rule
@@ -46,14 +47,14 @@ public class HtmlReportTest extends BaseReportTest {
   public void setUp() {
     result = mock(AnalysisResults.class);
     when(result.fileCount()).thenReturn(1);
-    reportFile = temp.getRoot().toPath().resolve("report.html");
+    reportFile = temp.getRoot().toPath().resolve("report.xml");
     sources = mock(SourceProvider.class);
-    html = new HtmlReport(temp.getRoot().toPath(), reportFile, sources);
+    xml = new XmlReport(temp.getRoot().toPath(), reportFile, sources);
   }
 
   @Test
-  public void testHtml() {
-    html.execute("project", new Date(), createTestIssues(temp.getRoot().toPath()), result);
+  public void testXml() {
+    xml.execute("project", new Date(), createTestIssues(temp.getRoot().toPath()), result);
   }
 
   private static List<IssueListener.Issue> createTestIssues(Path basePath) {


### PR DESCRIPTION
I've added support for the report in XML format.
this report quite simple yet, but could be improved later.
contains list of named issues with severity and count by file.
generates only if `--xml-report sonarlintreport.xml` was defined as an argument for `sonarlint` command
closes #8 