### PR TITLE
New mode - log issues to console

### DIFF
--- a/src/main/java/org/sonarlint/cli/Main.java
+++ b/src/main/java/org/sonarlint/cli/Main.java
@@ -159,8 +159,15 @@ public class Main {
       return;
     }
 
+    String reportType;
+    if (parsedOpts.reportType() != "") {
+      reportType = parsedOpts.reportType();
+    } else {
+      reportType = "html";
+    }
+
     InputFileFinder fileFinder = new InputFileFinder(parsedOpts.src(), parsedOpts.tests(), parsedOpts.exclusions(), charset);
-    ReportFactory reportFactory = new ReportFactory(charset);
+    ReportFactory reportFactory = new ReportFactory(charset, reportType);
     ConfigurationReader reader = new ConfigurationReader();
     SonarLintFactory sonarLintFactory = new SonarLintFactory(reader);
 

--- a/src/main/java/org/sonarlint/cli/Options.java
+++ b/src/main/java/org/sonarlint/cli/Options.java
@@ -36,6 +36,7 @@ public class Options {
   private String tests = "";
   private String exclusions = "";
   private String charset = null;
+  private String reportType = "";
   private boolean update = false;
   private String task;
 
@@ -92,6 +93,10 @@ public class Options {
           checkAdditionalArg(i, args.length, arg);
           options.exclusions = args[i];
 
+        } else if ("--reportType".equals(arg)) {
+          checkAdditionalArg(i, args.length, arg);
+          options.reportType = args[i];
+
         } else if ("-D".equals(arg) || "--define".equals(arg)) {
           checkAdditionalArg(i, args.length, arg);
           appendPropertyTo(args[i], options.props);
@@ -125,6 +130,10 @@ public class Options {
 
   public String charset() {
     return charset;
+  }
+
+  public String reportType() {
+    return reportType;
   }
 
   public String htmlReport() {
@@ -180,6 +189,7 @@ public class Options {
     LOGGER.info(" --tests <glob pattern>   GLOB pattern to identify test files");
     LOGGER.info(" --exclude <glob pattern> GLOB pattern to exclude files");
     LOGGER.info(" --charset <name>         Character encoding of the source files");
+    LOGGER.info(" --reportType <type>      Type of generated report. Can be 'html' or 'console'. 'html' by default.");
   }
 
   private static void appendPropertyTo(String arg, Properties props) {

--- a/src/main/java/org/sonarlint/cli/report/ConsoleReport.java
+++ b/src/main/java/org/sonarlint/cli/report/ConsoleReport.java
@@ -58,13 +58,14 @@ public class ConsoleReport implements Reporter {
       if (verboseConsoleLog) {
         sb.append(
           String.format(
-            "{%s} {%s} {%d:%d - %d:%d} {%s}\n",
+            "{%s} {%s} {%d:%d - %d:%d} {%s} {%s}\n",
             issue.getInputFile().getPath(),
             issue.getSeverity(),
             issue.getStartLine(),
             issue.getStartLineOffset(),
             issue.getEndLine(),
             issue.getEndLineOffset(),
+            issue.getRuleKey(),
             issue.getMessage()));
       }
       switch (issue.getSeverity()) {

--- a/src/main/java/org/sonarlint/cli/report/ConsoleReport.java
+++ b/src/main/java/org/sonarlint/cli/report/ConsoleReport.java
@@ -35,8 +35,14 @@ public class ConsoleReport implements Reporter {
   public static final String CONSOLE_REPORT_ENABLED_KEY = "sonar.issuesReport.console.enable";
   private static final int LEFT_PAD = 10;
 
-  ConsoleReport() {
+  private boolean verboseConsoleLog;
 
+  ConsoleReport() {
+    this(false);
+  }
+
+  ConsoleReport(boolean verboseConsoleLog) {
+    this.verboseConsoleLog = verboseConsoleLog;
   }
 
   private static class Report {
@@ -47,8 +53,20 @@ public class ConsoleReport implements Reporter {
     int minorIssues = 0;
     int infoIssues = 0;
 
-    public void process(Issue issue) {
+    public void process(Issue issue, StringBuilder sb, boolean verboseConsoleLog) {
       totalIssues++;
+      if (verboseConsoleLog) {
+        sb.append(
+          String.format(
+            "{%s} {%s} {%d:%d - %d:%d} {%s}\n",
+            issue.getInputFile().getPath(),
+            issue.getSeverity(),
+            issue.getStartLine(),
+            issue.getStartLineOffset(),
+            issue.getEndLine(),
+            issue.getEndLineOffset(),
+            issue.getMessage()));
+      }
       switch (issue.getSeverity()) {
         case "BLOCKER":
           blockerIssues++;
@@ -78,14 +96,14 @@ public class ConsoleReport implements Reporter {
   @Override
   public void execute(String projectName, Date date, List<Issue> issues, AnalysisResults result, Function<String, RuleDetails> ruleDescriptionProducer) {
     Report r = new Report();
+    StringBuilder sb = new StringBuilder();
     for (Issue issue : issues) {
-      r.process(issue);
+      r.process(issue, sb, verboseConsoleLog);
     }
-    printReport(r, result);
+    printReport(r, result, sb);
   }
 
-  public void printReport(Report r, AnalysisResults result) {
-    StringBuilder sb = new StringBuilder();
+  public void printReport(Report r, AnalysisResults result, StringBuilder sb) {
 
     sb.append("\n\n" + HEADER + "\n\n");
     if (result.fileCount() == 0) {

--- a/src/main/java/org/sonarlint/cli/report/ReportFactory.java
+++ b/src/main/java/org/sonarlint/cli/report/ReportFactory.java
@@ -26,22 +26,34 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 public class ReportFactory {
   private static final String DEFAULT_REPORT_PATH = ".sonarlint/sonarlint-report.html";
   private String htmlPath = null;
   private Charset charset;
+  private String reportType;
 
   public ReportFactory(Charset charset) {
+    this(charset, "");
+  }
+
+  public ReportFactory(Charset charset, String reportType) {
     this.charset = charset;
+    this.reportType = reportType;
   }
 
   public List<Reporter> createReporters(Path basePath) {
     List<Reporter> list = new LinkedList<>();
 
-    list.add(new ConsoleReport());
-    list.add(new HtmlReport(basePath, getReportFile(basePath), charset));
+    if (Objects.equals(reportType, "") || Objects.equals(reportType.toLowerCase(), "html")) {
+      list.add(new ConsoleReport());
+      list.add(new HtmlReport(basePath, getReportFile(basePath), charset));
+    } else if (Objects.equals(reportType.toLowerCase(), "console")) {
+      boolean verboseConsoleLog = true;
+      list.add(new ConsoleReport(verboseConsoleLog));
+    }
 
     return list;
   }

--- a/src/test/java/org/sonarlint/cli/OptionsTest.java
+++ b/src/test/java/org/sonarlint/cli/OptionsTest.java
@@ -71,6 +71,12 @@ public class OptionsTest {
   }
 
   @Test
+  public void testReportType() throws ParseException {
+    Options opt = Options.parse(args("--reportType", "html"));
+    assertThat(opt.reportType()).isEqualTo("html");
+  }
+
+  @Test
   public void testUpdate() throws ParseException {
     Options opt = Options.parse(args("-u"));
     assertThat(opt.isUpdate()).isTrue();

--- a/src/test/java/org/sonarlint/cli/report/ConsoleReportTest.java
+++ b/src/test/java/org/sonarlint/cli/report/ConsoleReportTest.java
@@ -83,6 +83,38 @@ public class ConsoleReportTest {
   }
 
   @Test
+  public void testVerboseLog() throws IOException {
+
+    ConsoleReport verboseReport = new ConsoleReport(true);
+
+    List<Issue> issues = new LinkedList<>();
+    issues.add(createTestIssue("comp1", "rule", "MAJOR", 20));
+    issues.add(createTestIssue("comp1", "rule", "MINOR", 20));
+    issues.add(createTestIssue("comp1", "rule", "CRITICAL", 20));
+    issues.add(createTestIssue("comp1", "rule", "INFO", 20));
+    issues.add(createTestIssue("comp1", "rule", "BLOCKER", 20));
+
+    verboseReport.execute(PROJECT_NAME, DATE, issues, result, k -> null);
+
+    stdOut.flush();
+    assertThat(getLog(out)).contains("SonarLint Report");
+    assertThat(getLog(out)).contains("5 issues");
+    assertThat(getLog(out)).contains("1 major");
+    assertThat(getLog(out)).contains("1 minor");
+    assertThat(getLog(out)).contains("1 info");
+    assertThat(getLog(out)).contains("1 critical");
+    assertThat(getLog(out)).contains("1 blocker");
+
+    assertThat(getLog(out)).contains("{comp1} {MAJOR} {20:0 - 0:0} {null}");
+    assertThat(getLog(out)).contains("{comp1} {MINOR} {20:0 - 0:0} {null}");
+    assertThat(getLog(out)).contains("{comp1} {CRITICAL} {20:0 - 0:0} {null}");
+    assertThat(getLog(out)).contains("{comp1} {INFO} {20:0 - 0:0} {null}");
+    assertThat(getLog(out)).contains("{comp1} {BLOCKER} {20:0 - 0:0} {null}");
+
+    assertThat(getLog(out)).doesNotContain("new");
+  }
+
+  @Test
   public void testInvalidSeverity() throws IOException {
     List<Issue> issues = new LinkedList<>();
     issues.add(createTestIssue("comp1", "rule", "INVALID", 10));

--- a/src/test/java/org/sonarlint/cli/report/ConsoleReportTest.java
+++ b/src/test/java/org/sonarlint/cli/report/ConsoleReportTest.java
@@ -105,11 +105,11 @@ public class ConsoleReportTest {
     assertThat(getLog(out)).contains("1 critical");
     assertThat(getLog(out)).contains("1 blocker");
 
-    assertThat(getLog(out)).contains("{comp1} {MAJOR} {20:0 - 0:0} {null}");
-    assertThat(getLog(out)).contains("{comp1} {MINOR} {20:0 - 0:0} {null}");
-    assertThat(getLog(out)).contains("{comp1} {CRITICAL} {20:0 - 0:0} {null}");
-    assertThat(getLog(out)).contains("{comp1} {INFO} {20:0 - 0:0} {null}");
-    assertThat(getLog(out)).contains("{comp1} {BLOCKER} {20:0 - 0:0} {null}");
+    assertThat(getLog(out)).contains("{comp1} {MAJOR} {20:0 - 0:0} {rule} {null}");
+    assertThat(getLog(out)).contains("{comp1} {MINOR} {20:0 - 0:0} {rule} {null}");
+    assertThat(getLog(out)).contains("{comp1} {CRITICAL} {20:0 - 0:0} {rule} {null}");
+    assertThat(getLog(out)).contains("{comp1} {INFO} {20:0 - 0:0} {rule} {null}");
+    assertThat(getLog(out)).contains("{comp1} {BLOCKER} {20:0 - 0:0} {rule} {null}");
 
     assertThat(getLog(out)).doesNotContain("new");
   }

--- a/src/test/java/org/sonarlint/cli/report/ReportFactoryTest.java
+++ b/src/test/java/org/sonarlint/cli/report/ReportFactoryTest.java
@@ -49,6 +49,13 @@ public class ReportFactoryTest {
   }
 
   @Test
+  public void consoleRun() {
+    ReportFactory tempFactory = new ReportFactory(Charset.defaultCharset(), "console");
+    List<Reporter> reporters = tempFactory.createReporters(Paths.get("test"));
+    assertThat(reporters).hasSize(1);
+  }
+
+  @Test
   public void defaultReportFile() {
     Path report = factory.getReportFile(temp.getRoot().toPath());
     assertThat(report).isEqualTo(temp.getRoot().toPath().resolve(".sonarlint").resolve("sonarlint-report.html"));


### PR DESCRIPTION
Hello, guys.

I've developed new extension for SonarLint support in Visual Studio Code.
It can be found [here](https://github.com/silverbulleters/sonarlint-vsc), if you interested. Not published to marketplace yet.
To easy connect sonarlint-cli to VSC (and other editors, Atom ie.) I need:
* add issue logging to console output
* deactivate html-report to enchance perfomance

I've added a new `--reportType` key.
If it unset or set to `html` - default report is generated. Old behavior is saved.
If it set to `console` - issues are logged to console output. Also html-report is deactivated.

Please, review.